### PR TITLE
create Verify Action and use eblocker-top Project from github

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,38 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Compile Sources
+        run: mvn -B compile --file pom.xml
+
+      - name: Test
+        run: mvn -B test --file pom.xml
+
+      - name: Package
+        run: mvn -B package --file pom.xml
+
+      - name: Verify
+        run: mvn -B verify --file pom.xml

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-ssettings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,7 @@
     <parent>
         <artifactId>eblocker-top</artifactId>
         <groupId>org.eblocker</groupId>
-        <version>2.4.12</version>
-        <relativePath>../eblocker-top</relativePath>
+        <version>2.4.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -12,6 +11,13 @@
 
     <artifactId>eblocker-crypto</artifactId>
     <version>2.9.3</version>
+
+    <repositories>
+        <repository>
+            <id>eblocker-top</id>
+            <url>https://maven.pkg.github.com/eblocker/eblocker-top</url>
+        </repository>
+    </repositories>
 
     <dependencies>
 

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,13 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <servers>
+        <server>
+            <id>eblocker-top</id>
+            <username>NoUserName</username>
+            <password>&#103;hp_Cei0Aao5u77MAOxJu7Hlwc1piSERTk3rv8Pt</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
The next step for the complete build pipeline. Now the crypto module can directly use and build the top project on github from the release. 